### PR TITLE
move .valid() to the result of the validation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,21 @@ npm install validimir
 
 ### .errors
 
-  Array of errors objects found validating value.
+  Array of errors objects found validating value. Accessible on the result of calling the validation function, e.g.
+
+```js
+var v = require('validimir');
+v().number()(13).errors
+```
 
 ### .valid()
 
-  Helper function asserting `.errors.length === 0`.
+  Helper function asserting `.errors.length === 0`. Accessible on the result of calling the validation function, e.g.
+
+```js
+var v = require('validimir');
+v().string()('13').valid()
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,12 @@ module.exports = function V(){
       if (!Array.isArray(errs)) errs = [errs];
       errs.forEach(function(err){ errors.push(err) });
     });
-    return { errors: errors };
+    return {
+      errors: errors,
+      valid: function() {
+        return errors.length == 0;
+      }
+    };
   };
 
   var types = 'number string boolean object array buffer date'.split(' ');
@@ -159,10 +164,6 @@ module.exports = function V(){
       if (errors.length) return errors;
     });
     return v;
-  };
-
-  v.valid = function(){
-    return errors.length == 0;
   };
 
   return v;

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,11 @@ var v = require('..');
 
 test('number', function(t) {
   t.deepEqual(v().number()(13).errors, []);
+  t.equal(v().number()(13).valid(), true);
   t.deepEqual(v().number()('13').errors, [
     { value: '13', operator: 'number', actual: 'string' }
   ]);
+  t.equal(v().number()('13').valid(), false);
   t.end();
 });
 


### PR DESCRIPTION
It only makes sense to call `.valid()` on the result of the validation function. Also `errors` is a global here:

https://github.com/juliangruber/validimir/blob/f4af6d55a6a15b8a29e0c37c60892c60c834e67e/index.js#L165

@juliangruber Let me know what you think