### PR TITLE
Add messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,28 @@ fn({ foo: 'bar', beep: 'boop' });
 // => { errors: [] }
 
 fn({ foo: 'bar', beep: 2 });
-// => { errors: [{ value: 2, operator: 'string', actual: 'number' }] }
+// => { errors: [{
+//      value: 2,
+//      operator: 'string',
+//      actual: 'number',
+//      message: 'Expected a string but got a number'
+//    }] }
 
 fn({ beep: 2 });
 // => { errors: [
-//      { value: 2, operator: 'string', actual: 'number' },
-//      { value: { beep: 2 }, operator: 'hasKey', excepted: 'foo' }
-//     ]}
+//      {
+//        value: 2,
+//        operator: 'string',
+//        actual: 'number',
+//        message: 'Expected a string but got a number'
+//      },
+//      {
+//        value: { beep: 2 },
+//        operator: 'hasKey',
+//        excepted: 'foo',
+//        message: 'Expected {"beep":2} to have key foo'
+//      }
+//    ]}
 ```
 
 ## Installation
@@ -37,21 +52,23 @@ npm install validimir
 
 ## API
 
+  Validimir will provide you with a useable `.message` for errors, or you can pass in your own to each method.
+
 ### v()
 
   Create a new validation function.
 
-### .number()
-### .string()
-### .boolean()
-### .object()
-### .array()
-### .buffer()
-### .date()
+### .number([message])
+### .string([message])
+### .boolean([message])
+### .object([message])
+### .array([message])
+### .buffer([message])
+### .date([message])
 
   Assert value is of given type. Types are exact, so `.array()` won't accept an object and vice versa.
 
-### .email()
+### .email([message])
 
   Assert value is a valid email. The regular expression used is:
 
@@ -59,26 +76,26 @@ npm install validimir
 /^([\w_\.\-\+])+\@([\w\-]+\.)+([\w]{2,10})+$/
 ```
 
-### .equal(value)
-### .notEqual(value)
+### .equal(value[, message])
+### .notEqual(value[, message])
 
   Assert value is (or not) equal to `value`. [ltgt](http://npmjs.org/package/ltgt) ranges can be used as well.
 
-### .match(reg)
-### .notMatch(reg)
+### .match(reg[, message])
+### .notMatch(reg[, message])
 
   Assert value matches (or doesn't match) regular expression `reg`.
 
-### .hasKey(key)
+### .hasKey(key[, message])
 
   Assert object value has key `key`.
 
-### .len(length)
+### .len(length[, message])
 
   Assert value is of length `length`. [ltgt](http://npmjs.org/package/ltgt) ranges can be used as well.
 
-### .of(array)
-### .notOf(array)
+### .of(array[, message])
+### .notOf(array[, message])
 
   Assert value can (or can't) be found in `array`.
 

--- a/index.js
+++ b/index.js
@@ -153,12 +153,13 @@ module.exports = function V(){
     return v;
   };
 
-  v.of = function(arr){
+  v.of = function(arr, msg){
     checks.push(function(v){
       if (arr.indexOf(v) == -1) return {
         value: v,
         operator: 'of',
-        expected: arr
+        expected: arr,
+        message: msg || fmt('Expected %j to be of %j', v, arr)
       };
     });
     return v;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var type = require('component-type');
 var ltgt = require('ltgt');
+var fmt = require('util').format;
 
 module.exports = function V(){
   var checks = [];
@@ -21,12 +22,13 @@ module.exports = function V(){
 
   var types = 'number string boolean object array buffer date'.split(' ');
   types.forEach(function(t){
-    v[t] = function(){
+    v[t] = function(msg){
       checks.push(function(v){
         if (type(v) != t) return {
           value: v,
           operator: t,
-          actual: type(v)
+          actual: type(v),
+          message: msg || fmt('Expected a %s but got a %s', t, type(v))
         };
       });
       return v;

--- a/index.js
+++ b/index.js
@@ -35,11 +35,12 @@ module.exports = function V(){
     };
   });
 
-  v.email = function(){
+  v.email = function(msg){
     checks.push(function(e){
       if (!/^([\w_\.\-\+])+\@([\w\-]+\.)+([\w]{2,10})+$/.test(e)) return {
         value: e,
-        operator: 'email'
+        operator: 'email',
+        message: msg || 'Expected a valid email address'
       };
     });
     return v;

--- a/index.js
+++ b/index.js
@@ -165,12 +165,13 @@ module.exports = function V(){
     return v;
   };
 
-  v.notOf = function(arr){
+  v.notOf = function(arr, msg){
     checks.push(function(v){
       if (arr.indexOf(v) > -1) return {
         value: v,
         operator: 'notOf',
-        expected: arr
+        expected: arr,
+        message: msg || fmt('Expected %j not to be of %j', v, arr)
       };
     });
     return v;

--- a/index.js
+++ b/index.js
@@ -127,14 +127,15 @@ module.exports = function V(){
     return v;
   };
 
-  v.len = function(l){
+  v.len = function(l, msg){
     if (typeof l == 'number') {
       checks.push(function(s){
         if (s.length != l) return {
           value: s,
           operator: 'len',
           expected: l,
-          actual: s.length
+          actual: s.length,
+          message: msg || fmt('Expected %j to have length %s', s, l)
         };
       });
     } else {
@@ -143,7 +144,9 @@ module.exports = function V(){
           value: s,
           operator: 'len',
           expected: l,
-          actual: s.length
+          actual: s.length,
+          message: msg
+            || fmt('Expected %j to be of length %s', s, toInterval(l))
         };
       });
     }

--- a/index.js
+++ b/index.js
@@ -70,12 +70,14 @@ module.exports = function V(){
     return v;
   };
 
-  v.notEqual = function(notExpected){
+  v.notEqual = function(notExpected, msg){
     if (typeof notExpected == 'object') {
       checks.push(function(v){
         if (ltgt.contains(notExpected, v)) return {
           value: v,
           operator: 'notEqual',
+          message: msg
+            || fmt('Expected a value outside range %s', toInterval(notExpected))
         };
       });
     } else {
@@ -83,6 +85,7 @@ module.exports = function V(){
         if (v === notExpected) return {
           value: v,
           operator: 'notEqual',
+          message: msg || fmt('Expected %j not to equal %j', v, notExpected)
         };
       });
     }

--- a/index.js
+++ b/index.js
@@ -92,12 +92,13 @@ module.exports = function V(){
     return v;
   };
 
-  v.match = function(reg){
+  v.match = function(reg, msg){
     checks.push(function(v){
       if (!reg.test(v)) return {
         value: v,
         operator: 'match',
-        expected: reg
+        expected: reg,
+        message: msg || fmt('Expected %j to match %s', v, reg)
       };
     });
     return v;

--- a/index.js
+++ b/index.js
@@ -115,12 +115,13 @@ module.exports = function V(){
     return v;
   };
 
-  v.hasKey = function(k){
+  v.hasKey = function(k, msg){
     checks.push(function(o){
       if (type(o) != 'object' || !(k in o)) return {
         value: o,
         operator: 'hasKey',
-        expected: k
+        expected: k,
+        message: msg || fmt('Expected %j to have key %s', o, k)
       };
     });
     return v;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var type = require('component-type');
 var ltgt = require('ltgt');
 var fmt = require('util').format;
+var toInterval = require('ltgt-to-interval');
 
 module.exports = function V(){
   var checks = [];
@@ -46,13 +47,14 @@ module.exports = function V(){
     return v;
   };
 
-  v.equal = function(expected){
+  v.equal = function(expected, msg){
     if (typeof expected == 'object') {
       checks.push(function(v){
         if (!ltgt.contains(expected, v)) return {
           value: v,
           operator: 'equal',
-          expected: expected
+          expected: expected,
+          message: msg || fmt('Expected a value in range %s', toInterval(expected))
         };
       });
     } else {
@@ -60,7 +62,8 @@ module.exports = function V(){
         if (v !== expected) return {
           value: v,
           operator: 'equal',
-          expected: expected
+          expected: expected,
+          message: msg || fmt('Expected %j to equal %j', v, expected)
         };
       });
     }

--- a/index.js
+++ b/index.js
@@ -104,11 +104,12 @@ module.exports = function V(){
     return v;
   };
 
-  v.notMatch = function(reg){
+  v.notMatch = function(reg, msg){
     checks.push(function(v){
       if (reg.test(v)) return {
         value: v,
-        operator: 'notMatch'
+        operator: 'notMatch',
+        message: msg || fmt('Expected %j not to match %s', v, reg)
       };
     });
     return v;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "component-type": "^1.2.0",
     "ltgt": "^2.1.0",
+    "ltgt-to-interval": "^1.0.0",
     "quote-unquote": "^1.0.0"
   },
   "devDependencies": {

--- a/test/each.js
+++ b/test/each.js
@@ -7,10 +7,20 @@ test('each', function(t) {
   t.deepEqual(validate(['foo', 'bar']).errors, []);
   t.deepEqual(validate({ foo: 'foo', bar: 'bar' }).errors, []);
   t.deepEqual(validate(['foo', 13]).errors, [
-    { value: 13, operator: 'string', actual: 'number' }
+    {
+      value: 13,
+      operator: 'string',
+      actual: 'number',
+      message: 'Expected a string but got a number'
+    }
   ]);
   t.deepEqual(validate({ foo: 13 }).errors, [
-    { value: 13, operator: 'string', actual: 'number' }  
+    {
+      value: 13,
+      operator: 'string',
+      actual: 'number',
+      message: 'Expected a string but got a number'
+    }
   ]);
 
   t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -260,7 +260,12 @@ test('len', function(t) {
 test('of', function(t) {
   t.deepEqual(v().of(['foo', 'bar'])('foo').errors, []);
   t.deepEqual(v().of(['foo'])('bar').errors, [
-    { value: 'bar', operator: 'of', expected: ['foo'] }
+    {
+      value: 'bar',
+      operator: 'of',
+      expected: ['foo'],
+      message: 'Expected "bar" to be of ["foo"]'
+    }
   ]);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -176,7 +176,12 @@ test('notEqual', function(t) {
 test('match', function(t) {
   t.deepEqual(v().match(/foo/)('foo').errors, []);
   t.deepEqual(v().match(/foo/)('f').errors, [
-    { value: 'f', operator: 'match', expected: /foo/ }
+    {
+      value: 'f',
+      operator: 'match',
+      expected: /foo/,
+      message: 'Expected "f" to match /foo/'
+    }
   ]);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -97,7 +97,11 @@ test('date', function(t) {
 test('email', function(t) {
   t.deepEqual(v().email()('foo@bar.com').errors, []);
   t.deepEqual(v().email()('foo@bar').errors, [
-    { value: 'foo@bar', operator: 'email' }
+    {
+      value: 'foo@bar',
+      operator: 'email',
+      message: 'Expected a valid email address'
+    }
   ]);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,14 @@ test('number', function(t) {
       message: 'Expected a number but got a string'
     }
   ]);
+  t.deepEqual(v().number('number')('13').errors, [
+    {
+      value: '13',
+      operator: 'number',
+      actual: 'string',
+      message: 'number'
+    }
+  ]);
   t.equal(v().number()('13').valid(), false);
   t.end();
 });
@@ -24,6 +32,14 @@ test('string', function(t) {
       operator: 'string',
       actual: 'number',
       message: 'Expected a string but got a number'
+    }
+  ]);
+  t.deepEqual(v().string('string')(13).errors, [
+    {
+      value: 13,
+      operator: 'string',
+      actual: 'number',
+      message: 'string'
     }
   ]);
   t.end();
@@ -39,6 +55,14 @@ test('boolean', function(t) {
       message: 'Expected a boolean but got a string'
     } 
   ]);
+  t.deepEqual(v().boolean('boolean')('true').errors, [
+    {
+      value: 'true',
+      operator: 'boolean',
+      actual: 'string',
+      message: 'boolean'
+    } 
+  ]);
   t.end();
 });
 
@@ -50,6 +74,14 @@ test('object', function(t) {
       operator: 'object',
       actual: 'string',
       message: 'Expected a object but got a string'
+    } 
+  ]);
+  t.deepEqual(v().object('object')('true').errors, [
+    {
+      value: 'true',
+      operator: 'object',
+      actual: 'string',
+      message: 'object'
     } 
   ]);
   t.end();
@@ -65,6 +97,14 @@ test('array', function(t) {
       message: 'Expected a array but got a string'
     }
   ]);
+  t.deepEqual(v().array('array')('true').errors, [
+    {
+      value: 'true',
+      operator: 'array',
+      actual: 'string',
+      message: 'array'
+    }
+  ]);
   t.end();
 });
 
@@ -76,6 +116,14 @@ test('buffer', function(t) {
       operator: 'buffer',
       actual: 'object',
       message: 'Expected a buffer but got a object'
+    }
+  ]);
+  t.deepEqual(v().buffer('buffer')({}).errors, [
+    {
+      value: {},
+      operator: 'buffer',
+      actual: 'object',
+      message: 'buffer'
     }
   ]);
   t.end();
@@ -91,6 +139,14 @@ test('date', function(t) {
       message: 'Expected a date but got a object'
     } 
   ]);
+  t.deepEqual(v().date('date')({}).errors, [
+    {
+      value: {},
+      operator: 'date',
+      actual: 'object',
+      message: 'date'
+    } 
+  ]);
   t.end();
 });
 
@@ -101,6 +157,13 @@ test('email', function(t) {
       value: 'foo@bar',
       operator: 'email',
       message: 'Expected a valid email address'
+    }
+  ]);
+  t.deepEqual(v().email('email')('foo@bar').errors, [
+    {
+      value: 'foo@bar',
+      operator: 'email',
+      message: 'email'
     }
   ]);
   t.end();
@@ -124,6 +187,14 @@ test('equal', function(t) {
       message: 'Expected 2 to equal 1'
     }
   ]);
+  t.deepEqual(v().equal(1, 'equal')(2).errors, [
+    {
+      value: 2,
+      operator: 'equal',
+      expected: 1,
+      message: 'equal'
+    }
+  ]);
 
 
   t.deepEquals(v().equal('1')(1).errors, [
@@ -140,6 +211,14 @@ test('equal', function(t) {
       operator: 'equal',
       expected: { gt: 4 },
       message: 'Expected a value in range (4,'
+    } 
+  ]);
+  t.deepEquals(v().equal({ gt: 4 }, 'equal')(3).errors, [
+    {
+      value: 3,
+      operator: 'equal',
+      expected: { gt: 4 },
+      message: 'equal'
     } 
   ]);
   t.deepEqual(v().equal({ gt: 'b' })('a').errors, [
@@ -163,11 +242,25 @@ test('notEqual', function(t) {
       message: 'Expected "1" not to equal "1"'
     }
   ]);
+  t.deepEqual(v().notEqual('1', 'not equal')('1').errors, [
+    {
+      value: '1',
+      operator: 'notEqual',
+      message: 'not equal'
+    }
+  ]);
   t.deepEqual(v().notEqual({ gt: 3, lt: 5 })(4).errors, [
     {
       value: 4,
       operator: 'notEqual',
       message: 'Expected a value outside range (3,5)'
+    }
+  ]);
+  t.deepEqual(v().notEqual({ gt: 3, lt: 5 }, 'not equal')(4).errors, [
+    {
+      value: 4,
+      operator: 'notEqual',
+      message: 'not equal'
     }
   ]);
   t.end();
@@ -183,6 +276,14 @@ test('match', function(t) {
       message: 'Expected "f" to match /foo/'
     }
   ]);
+  t.deepEqual(v().match(/foo/, 'match')('f').errors, [
+    {
+      value: 'f',
+      operator: 'match',
+      expected: /foo/,
+      message: 'match'
+    }
+  ]);
   t.end();
 });
 
@@ -193,6 +294,13 @@ test('notMatch', function(t) {
       value: 'foo',
       operator: 'notMatch',
       message: 'Expected "foo" not to match /foo/'
+    }
+  ]);
+  t.deepEqual(v().notMatch(/foo/, 'not match')('foo').errors, [
+    {
+      value: 'foo',
+      operator: 'notMatch',
+      message: 'not match'
     }
   ]);
   t.end();
@@ -206,6 +314,14 @@ test('hasKey', function(t) {
       operator: 'hasKey',
       expected: 'b',
       message: 'Expected {"a":"b"} to have key b'
+    }
+  ]);
+  t.deepEqual(v().hasKey('b', 'has key')({a:'b'}).errors, [
+    {
+      value: { a: 'b' },
+      operator: 'hasKey',
+      expected: 'b',
+      message: 'has key'
     }
   ]);
   t.end();
@@ -226,6 +342,15 @@ test('len', function(t) {
       message: 'Expected "a" to have length 13'
     }
   ]);
+  t.deepEqual(v().len(13, 'len')('a').errors, [
+    {
+      value: 'a',
+      operator: 'len',
+      expected: 13,
+      actual: 1,
+      message: 'len'
+    }
+  ]);
   t.deepEqual(v().len({ gt: 3 })('a').errors, [
     {
       value: 'a',
@@ -233,6 +358,15 @@ test('len', function(t) {
       expected: { gt: 3 },
       actual: 1,
       message: 'Expected "a" to be of length (3,'
+    }
+  ]);
+  t.deepEqual(v().len({ gt: 3 }, 'len')('a').errors, [
+    {
+      value: 'a',
+      operator: 'len',
+      expected: { gt: 3 },
+      actual: 1,
+      message: 'len'
     }
   ]);
   t.deepEqual(v().len({ lte: 3 })('aaaaa').errors, [
@@ -267,6 +401,14 @@ test('of', function(t) {
       message: 'Expected "bar" to be of ["foo"]'
     }
   ]);
+  t.deepEqual(v().of(['foo'], 'of')('bar').errors, [
+    {
+      value: 'bar',
+      operator: 'of',
+      expected: ['foo'],
+      message: 'of'
+    }
+  ]);
   t.end();
 });
 
@@ -278,6 +420,14 @@ test('notOf', function(t) {
       operator: 'notOf',
       expected: ['foo'],
       message: 'Expected "foo" not to be of ["foo"]'
+    }
+  ]);
+  t.deepEqual(v().notOf(['foo'], 'not of')('foo').errors, [
+    {
+      value: 'foo',
+      operator: 'notOf',
+      expected: ['foo'],
+      message: 'not of'
     }
   ]);
   t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -189,7 +189,11 @@ test('match', function(t) {
 test('notMatch', function(t) {
   t.deepEqual(v().notMatch(/foo/)('f').errors, []);
   t.deepEqual(v().notMatch(/foo/)('foo').errors, [
-    { value: 'foo', operator: 'notMatch' }
+    {
+      value: 'foo',
+      operator: 'notMatch',
+      message: 'Expected "foo" not to match /foo/'
+    }
   ]);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -273,7 +273,12 @@ test('of', function(t) {
 test('notOf', function(t) {
   t.deepEqual(v().notOf(['foo', 'bar'])('baz').errors, []);
   t.deepEqual(v().notOf(['foo'])('foo').errors, [
-    { value: 'foo', operator: 'notOf', expected: ['foo'] }
+    {
+      value: 'foo',
+      operator: 'notOf',
+      expected: ['foo'],
+      message: 'Expected "foo" not to be of ["foo"]'
+    }
   ]);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -117,18 +117,38 @@ test('equal', function(t) {
   t.deepEqual(v().equal({ lt: 'b' })('a').errors, []);
 
   t.deepEqual(v().equal(1)(2).errors, [
-    { value: 2, operator: 'equal', expected: 1 }
+    {
+      value: 2,
+      operator: 'equal',
+      expected: 1,
+      message: 'Expected 2 to equal 1'
+    }
   ]);
 
 
   t.deepEquals(v().equal('1')(1).errors, [
-    { value: 1, operator: 'equal', expected: '1' }  
+    {
+      value: 1,
+      operator: 'equal',
+      expected: '1',
+      message: 'Expected 1 to equal "1"'
+    } 
   ]);
   t.deepEquals(v().equal({ gt: 4 })(3).errors, [
-    { value: 3, operator: 'equal', expected: { gt: 4 } }  
+    {
+      value: 3,
+      operator: 'equal',
+      expected: { gt: 4 },
+      message: 'Expected a value in range (4,'
+    } 
   ]);
   t.deepEqual(v().equal({ gt: 'b' })('a').errors, [
-    { value: 'a', operator: 'equal', expected: { gt: 'b' } }
+    {
+      value: 'a',
+      operator: 'equal',
+      expected: { gt: 'b' },
+      message: 'Expected a value in range (b,'
+    }
   ]);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,12 @@ test('number', function(t) {
   t.deepEqual(v().number()(13).errors, []);
   t.equal(v().number()(13).valid(), true);
   t.deepEqual(v().number()('13').errors, [
-    { value: '13', operator: 'number', actual: 'string' }
+    {
+      value: '13',
+      operator: 'number',
+      actual: 'string',
+      message: 'Expected a number but got a string'
+    }
   ]);
   t.equal(v().number()('13').valid(), false);
   t.end();
@@ -14,7 +19,12 @@ test('number', function(t) {
 test('string', function(t) {
   t.deepEqual(v().string()('13').errors, []);
   t.deepEqual(v().string()(13).errors, [
-    { value: 13, operator: 'string', actual: 'number' }
+    {
+      value: 13,
+      operator: 'string',
+      actual: 'number',
+      message: 'Expected a string but got a number'
+    }
   ]);
   t.end();
 });
@@ -22,7 +32,12 @@ test('string', function(t) {
 test('boolean', function(t) {
   t.deepEqual(v().boolean()(true).errors, []);
   t.deepEqual(v().boolean()('true').errors, [
-    { value: 'true', operator: 'boolean', actual: 'string' }  
+    {
+      value: 'true',
+      operator: 'boolean',
+      actual: 'string',
+      message: 'Expected a boolean but got a string'
+    } 
   ]);
   t.end();
 });
@@ -30,16 +45,25 @@ test('boolean', function(t) {
 test('object', function(t) {
   t.deepEqual(v().object()({}).errors, []);
   t.deepEqual(v().object()('true').errors, [
-    { value: 'true', operator: 'object', actual: 'string' }  
+    {
+      value: 'true',
+      operator: 'object',
+      actual: 'string',
+      message: 'Expected a object but got a string'
+    } 
   ]);
   t.end();
 });
 
-
 test('array', function(t) {
   t.deepEqual(v().array()([]).errors, []);
   t.deepEqual(v().array()('true').errors, [
-    { value: 'true', operator: 'array', actual: 'string' }  
+    {
+      value: 'true',
+      operator: 'array',
+      actual: 'string',
+      message: 'Expected a array but got a string'
+    }
   ]);
   t.end();
 });
@@ -47,7 +71,12 @@ test('array', function(t) {
 test('buffer', function(t) {
   t.deepEqual(v().buffer()(new Buffer(0)).errors, []);
   t.deepEqual(v().buffer()({}).errors, [
-    { value: {}, operator: 'buffer', actual: 'object' }  
+    {
+      value: {},
+      operator: 'buffer',
+      actual: 'object',
+      message: 'Expected a buffer but got a object'
+    }
   ]);
   t.end();
 });
@@ -55,7 +84,12 @@ test('buffer', function(t) {
 test('date', function(t) {
   t.deepEqual(v().date()(new Date).errors, []);
   t.deepEqual(v().date()({}).errors, [
-    { value: {}, operator: 'date', actual: 'object' }  
+    {
+      value: {},
+      operator: 'date',
+      actual: 'object',
+      message: 'Expected a date but got a object'
+    } 
   ]);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -201,7 +201,12 @@ test('notMatch', function(t) {
 test('hasKey', function(t) {
   t.deepEqual(v().hasKey('a')({a:'b'}).errors, []);
   t.deepEqual(v().hasKey('b')({a:'b'}).errors, [
-    { value: { a: 'b' }, operator: 'hasKey', expected: 'b' }
+    {
+      value: { a: 'b' },
+      operator: 'hasKey',
+      expected: 'b',
+      message: 'Expected {"a":"b"} to have key b'
+    }
   ]);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -157,10 +157,18 @@ test('notEqual', function(t) {
   t.deepEqual(v().notEqual('1')(1).errors, []);
   t.deepEqual(v().notEqual({ gt: 3, lt: 5 })(6).errors, []);
   t.deepEqual(v().notEqual('1')('1').errors, [
-    { value: '1', operator: 'notEqual' }
+    {
+      value: '1',
+      operator: 'notEqual',
+      message: 'Expected "1" not to equal "1"'
+    }
   ]);
   t.deepEqual(v().notEqual({ gt: 3, lt: 5 })(4).errors, [
-    { value: 4, operator: 'notEqual' }
+    {
+      value: 4,
+      operator: 'notEqual',
+      message: 'Expected a value outside range (3,5)'
+    }
   ]);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -218,16 +218,40 @@ test('len', function(t) {
   t.deepEqual(v().len({ gt: 3, lte: 10 })('aaaaa').errors, []);
 
   t.deepEqual(v().len(13)('a').errors, [
-    { value: 'a', operator: 'len', expected: 13, actual: 1 }
+    {
+      value: 'a',
+      operator: 'len',
+      expected: 13,
+      actual: 1,
+      message: 'Expected "a" to have length 13'
+    }
   ]);
   t.deepEqual(v().len({ gt: 3 })('a').errors, [
-    { value: 'a', operator: 'len', expected: { gt: 3 }, actual: 1 }
+    {
+      value: 'a',
+      operator: 'len',
+      expected: { gt: 3 },
+      actual: 1,
+      message: 'Expected "a" to be of length (3,'
+    }
   ]);
   t.deepEqual(v().len({ lte: 3 })('aaaaa').errors, [
-    { value: 'aaaaa', operator: 'len', expected: { lte: 3 }, actual: 5 }
+    {
+      value: 'aaaaa',
+      operator: 'len',
+      expected: { lte: 3 },
+      actual: 5,
+      message: 'Expected "aaaaa" to be of length ,3]'
+    }
   ]);
   t.deepEqual(v().len({ gt: 3, lte: 10 })('a').errors, [
-    { value: 'a', operator: 'len', expected: { gt: 3, lte: 10 }, actual: 1 }
+    {
+      value: 'a',
+      operator: 'len',
+      expected: { gt: 3, lte: 10 },
+      actual: 1,
+      message: 'Expected "a" to be of length (3,10]'
+    }
   ]);
 
   t.end();


### PR DESCRIPTION
this adds automatic error messages that can be overwritten, like so:

```js
v()
  .len({ gt: 3 }, 'must be longer than 3')
  .match(/\d/, 'must contain a number')
```

cc @hij1nx
as in https://github.com/juliangruber/validimir/issues/10