### PR TITLE
Return error instead of throwing exception for len validator

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,6 +130,12 @@ module.exports = function V(){
   v.len = function(l, msg){
     if (typeof l == 'number') {
       checks.push(function(s){
+        if (s == null) return {
+          value: s,
+          operator: 'len',
+          expected: l,
+          actual: 'no length property'
+        }
         if (s.length != l) return {
           value: s,
           operator: 'len',
@@ -140,6 +146,12 @@ module.exports = function V(){
       });
     } else {
       checks.push(function(s){
+        if (s == null) return {
+          value: s,
+          operator: 'len',
+          expected: l,
+          actual: 'no length property'
+        }
         if (!ltgt.contains(l, s.length)) return {
           value: s,
           operator: 'len',

--- a/index.js
+++ b/index.js
@@ -134,7 +134,8 @@ module.exports = function V(){
           value: s,
           operator: 'len',
           expected: l,
-          actual: 'no length property'
+          actual: 'no length property',
+          message: msg || fmt('Expected %j to have length %s', s, l)
         }
         if (s.length != l) return {
           value: s,
@@ -150,7 +151,9 @@ module.exports = function V(){
           value: s,
           operator: 'len',
           expected: l,
-          actual: 'no length property'
+          actual: 'no length property',
+          message: msg
+            || fmt('Expected %j to be of length %s', s, toInterval(l))
         }
         if (!ltgt.contains(l, s.length)) return {
           value: s,

--- a/test/test.js
+++ b/test/test.js
@@ -396,7 +396,7 @@ test('len', function(t) {
   t.deepEqual(v().len({gt: 2})(undefined).errors, [
     { value: undefined, operator: 'len', expected: {gt: 2}, actual: 'no length property' }
   ]);
-  t.deepEqual(v().len({gt : 2})(null).errors, [
+  t.deepEqual(v().len({gt: 2})(null).errors, [
     { value: null, operator: 'len', expected: {gt: 2}, actual: 'no length property' }
   ]);
 

--- a/test/test.js
+++ b/test/test.js
@@ -387,6 +387,12 @@ test('len', function(t) {
       message: 'Expected "a" to be of length (3,10]'
     }
   ]);
+  t.deepEqual(v().len(1)(undefined).errors, [
+    { value: undefined, operator: 'len', expected: 1, actual: 'no length property' }
+  ]);
+  t.deepEqual(v().len(1)(null).errors, [
+    { value: null, operator: 'len', expected: 1, actual: 'no length property' }
+  ]);
 
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -53,7 +53,7 @@ test('boolean', function(t) {
       operator: 'boolean',
       actual: 'string',
       message: 'Expected a boolean but got a string'
-    } 
+    }
   ]);
   t.deepEqual(v().boolean('boolean')('true').errors, [
     {
@@ -61,7 +61,7 @@ test('boolean', function(t) {
       operator: 'boolean',
       actual: 'string',
       message: 'boolean'
-    } 
+    }
   ]);
   t.end();
 });
@@ -74,7 +74,7 @@ test('object', function(t) {
       operator: 'object',
       actual: 'string',
       message: 'Expected a object but got a string'
-    } 
+    }
   ]);
   t.deepEqual(v().object('object')('true').errors, [
     {
@@ -82,7 +82,7 @@ test('object', function(t) {
       operator: 'object',
       actual: 'string',
       message: 'object'
-    } 
+    }
   ]);
   t.end();
 });
@@ -137,7 +137,7 @@ test('date', function(t) {
       operator: 'date',
       actual: 'object',
       message: 'Expected a date but got a object'
-    } 
+    }
   ]);
   t.deepEqual(v().date('date')({}).errors, [
     {
@@ -145,7 +145,7 @@ test('date', function(t) {
       operator: 'date',
       actual: 'object',
       message: 'date'
-    } 
+    }
   ]);
   t.end();
 });
@@ -203,7 +203,7 @@ test('equal', function(t) {
       operator: 'equal',
       expected: '1',
       message: 'Expected 1 to equal "1"'
-    } 
+    }
   ]);
   t.deepEquals(v().equal({ gt: 4 })(3).errors, [
     {
@@ -211,7 +211,7 @@ test('equal', function(t) {
       operator: 'equal',
       expected: { gt: 4 },
       message: 'Expected a value in range (4,'
-    } 
+    }
   ]);
   t.deepEquals(v().equal({ gt: 4 }, 'equal')(3).errors, [
     {
@@ -219,7 +219,7 @@ test('equal', function(t) {
       operator: 'equal',
       expected: { gt: 4 },
       message: 'equal'
-    } 
+    }
   ]);
   t.deepEqual(v().equal({ gt: 'b' })('a').errors, [
     {

--- a/test/test.js
+++ b/test/test.js
@@ -393,6 +393,12 @@ test('len', function(t) {
   t.deepEqual(v().len(1)(null).errors, [
     { value: null, operator: 'len', expected: 1, actual: 'no length property' }
   ]);
+  t.deepEqual(v().len({gt: 2})(undefined).errors, [
+    { value: undefined, operator: 'len', expected: {gt: 2}, actual: 'no length property' }
+  ]);
+  t.deepEqual(v().len({gt : 2})(null).errors, [
+    { value: null, operator: 'len', expected: {gt: 2}, actual: 'no length property' }
+  ]);
 
   t.end();
 });


### PR DESCRIPTION
In this PR a check has been added to the `len` validator to return an error when `null` or `undefined` are passed to avoid throwing a exception.

This is useful to get an error object back when the `len` validator is combined with other validators such as the `string` one.

For example, before this PR:
```javascript
> validimir().string()(undefined)
{ errors: [ { value: undefined, operator: 'string', actual: 'undefined' } ],
  valid: [Function] }
> validimir().string().len({gt: 2})(undefined)
TypeError: Cannot read property 'length' of undefined
```

(Note that an error is returned by the `string` validator in both cases, but cannot be retrieved in the latter)

After this PR:

```javascript
> validimir().string().len({gt: 2})(undefined)
{ errors: 
   [ { value: undefined, operator: 'string', actual: 'undefined' },
     { value: undefined,
       operator: 'len',
       expected: [Object],
       actual: 'no length property' } ],
  valid: [Function] }
```