### PR TITLE
Fix len check with undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ module.exports.putin = function(key, value, cb) {
 };
 
 function getLength(obj){
-  return obj !== null && typeof obj.length != 'undefined'
+  return obj != null && typeof obj.length != 'undefined'
     ? obj.length
     : undefined;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -426,6 +426,15 @@ test('len', function(t) {
       message: 'Expected null to have length 3'
     }
   ]);
+  t.deepEqual(v().len(3)(undefined).errors, [
+    {
+      value: undefined,
+      operator: 'len',
+      expected: 3,
+      actual: undefined,
+      message: 'Expected undefined to have length 3'
+    }
+  ]);
   t.deepEqual(v().len({ gt:3 })(null).errors, [
     {
       value: null,
@@ -433,6 +442,15 @@ test('len', function(t) {
       expected: { gt: 3 },
       actual: undefined,
       message: 'Expected null to be of length (3,'
+    }
+  ]);
+  t.deepEqual(v().len({ gt:3 })(undefined).errors, [
+    {
+      value: undefined,
+      operator: 'len',
+      expected: { gt: 3 },
+      actual: undefined,
+      message: 'Expected undefined to be of length (3,'
     }
   ]);
 


### PR DESCRIPTION
This PR fixes the behavior of the `len` validator when `undefined` is passed.

Related #16