### PR TITLE
Add check public

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": "eslint:recommended",
+  "env":  {
+    "node": true
+  },
+  "rules": {
+    "camelcase": 2,
+    "semi": 2
+  }
+}

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ npm install validimir
 
 ```js
 var v = require('validimir');
-var isIP = require('validator').isIP
+var isIP = require('validator').isIP;
 var checkIP = function(value) {
   if (!isIP(value)) {
     return {
@@ -128,16 +128,16 @@ var checkIP = function(value) {
       message: 'Expected a valid IP address'
     }
   }
-}
-var fn = v().custom(checkIP)
+};
+var fn = v().custom(checkIP);
 
-fn('not an ip address').errors
 // [ { value: 'not an ip address',
 //     operator: 'ip',
 //     message: 'Expected a valid IP address' } ]
+fn('not an ip address').errors;
 
-fn('127.0.0.1').errors
 // []
+fn('127.0.0.1').errors;
 ```
 
 ### .errors

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ var v = require('validimir');
 var isIP = require('validator').isIP
 var check = function(value) {
   if (!isIP(value)) {
-    return {}
     return {
       value: value,
       operator: 'ip',

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ npm install validimir
 ```js
 var v = require('validimir');
 var isIP = require('validator').isIP
-var check = function(value) {
+var checkIP = function(value) {
   if (!isIP(value)) {
     return {
       value: value,
@@ -129,7 +129,7 @@ var check = function(value) {
     }
   }
 }
-var fn = v().custom(check)
+var fn = v().custom(checkIP)
 
 fn('not an ip')
 // { errors:

--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ var checkIP = function(value) {
 };
 var fn = v().custom(checkIP);
 
-// [ { value: 'not an ip address',
-//     operator: 'ip',
-//     message: 'Expected a valid IP address' } ]
 fn('not an ip address').errors;
+// => [ { value: 'not an ip address',
+//        operator: 'ip',
+//        message: 'Expected a valid IP address' } ]
 
-// []
 fn('127.0.0.1').errors;
+// => []
 ```
 
 ### .errors

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ fn('127.0.0.1').errors;
 
 ```js
 var v = require('validimir');
-v().number()(13).errors
+v().number()(13).errors;
 ```
 
 ### .valid()
@@ -155,7 +155,7 @@ v().number()(13).errors
 
 ```js
 var v = require('validimir');
-v().string()('13').valid()
+v().string()('13').valid();
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -103,39 +103,34 @@ npm install validimir
 
   Assert each of value - no matter whether it's an array or object - passes `fn` with should be a function returned by validimir or an api compatible module.
 
-### .addCheck(name, fn)
+### .custom(fn)
 
-  Add custom validator.
+  Add custom check.
 
-  This function adds a new validator `fn` under `name` and returns it to add it immediately if desired.
+  This function adds a new check function `fn`.
 
-  A validator is a function that gets two arguments:
-  - `expected`: The expected value. Used only on validators that need an `expected` value to check against.
-  - `msg` (optional): The error message to display in case of failure
-
-  The validation returns another function that gets the value to be checked, runs the check and returns either nothing (or any falsy value) on success or an error object on failure with the following properties:
+  A check function in validimir is a function that gets a value, tries to validate it and returns either nothing (or any falsy value) on success or an error object on failure. There are no strict requirements with regard to the error object, but to be consistent with other checks in validimir, it should have the following properties:
   - `value`: The value that didn't pass the validation
-  - `operator`: The name of the operator that failed. Ideally the same one as the `name` argument passed to `addCheck`)
-  - `message`: Error messsage. Either a default value or the `msg` argument if passed
-  - `expected`: The expected value (if passed to the validator)
+  - `operator`: The name of the operator that failed
+  - `message`: Descriptive error messsage
+  - `expected`: The expected value, if any, depending on the check
 
   Example:
 
 ```js
 var v = require('validimir');
 var isIP = require('validator').isIP
-var fn = v()
-fn.addCheck('ip', function(msg) {
-  return function(value) {
-    if (!isIP(value)) {
-      return {
-        value: value,
-        operator: 'ip',
-        message: msg || 'Expected a valid IP address'
-      }
+var check = function(value) {
+  if (!isIP(value)) {
+    return {}
+    return {
+      value: value,
+      operator: 'ip',
+      message: 'Expected a valid IP address'
     }
   }
-})()
+}
+var fn = v().custom(check)
 
 fn('not an ip')
 // { errors:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,51 @@ npm install validimir
 
   Assert each of value - no matter whether it's an array or object - passes `fn` with should be a function returned by validimir or an api compatible module.
 
+### .addCheck(name, fn)
+
+  Add custom validator.
+
+  This function adds a new validator `fn` under `name` and returns it to add it immediately if desired.
+
+  A validator is a function that gets two arguments:
+  - `expected`: The expected value. Used only on validators that need an `expected` value to check against.
+  - `msg` (optional): The error message to display in case of failure
+
+  The validation returns another function that gets the value to be checked, runs the check and returns either nothing (or any falsy value) on success or an error object on failure with the following properties:
+  - `value`: The value that didn't pass the validation
+  - `operator`: The name of the operator that failed. Ideally the same one as the `name` argument passed to `addCheck`)
+  - `message`: Error messsage. Either a default value or the `msg` argument if passed
+  - `expected`: The expected value (if passed to the validator)
+
+  Example:
+
+```js
+var v = require('validimir');
+var isIP = require('validator').isIP
+var fn = v()
+fn.addCheck('ip', function(msg) {
+  return function(value) {
+    if (!isIP(value)) {
+      return {
+        value: value,
+        operator: 'ip',
+        message: msg || 'Expected a valid IP address'
+      }
+    }
+  }
+})()
+
+fn('not an ip')
+// { errors:
+//    [ { value: 'not an ip',
+//        operator: 'ip',
+//        message: 'Expected a valid IP address' } ],
+//   valid: [Function] }
+
+fn('127.0.0.1')
+// { errors: [], valid: [Function] }
+```
+
 ### .errors
 
   Array of errors objects found validating value. Accessible on the result of calling the validation function, e.g.

--- a/README.md
+++ b/README.md
@@ -131,15 +131,13 @@ var checkIP = function(value) {
 }
 var fn = v().custom(checkIP)
 
-fn('not an ip')
-// { errors:
-//    [ { value: 'not an ip',
-//        operator: 'ip',
-//        message: 'Expected a valid IP address' } ],
-//   valid: [Function] }
+fn('not an ip address').errors
+// [ { value: 'not an ip address',
+//     operator: 'ip',
+//     message: 'Expected a valid IP address' } ]
 
-fn('127.0.0.1')
-// { errors: [], valid: [Function] }
+fn('127.0.0.1').errors
+// []
 ```
 
 ### .errors

--- a/index.js
+++ b/index.js
@@ -26,9 +26,7 @@ module.exports = function V(){
       checks.push(check);
       return v;
     };
-    return v[op]
   };
-  v.addCheck = addCheck
 
 
   // Add custom validator

--- a/index.js
+++ b/index.js
@@ -30,6 +30,13 @@ module.exports = function V(){
   };
   v.addCheck = addCheck
 
+
+  // Add custom validator
+  v.custom = function(fn) {
+    checks.push(fn);
+    return v;
+  };
+
   var types = 'number string boolean object array buffer date'.split(' ');
   types.forEach(function(t){
     addCheck(t, function(msg){

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = function V(){
       return v;
     };
   };
+  v.addCheck = addCheck
 
   var types = 'number string boolean object array buffer date'.split(' ');
   types.forEach(function(t){

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = function V(){
       checks.push(check);
       return v;
     };
+    return v[op]
   };
   v.addCheck = addCheck
 

--- a/index.js
+++ b/index.js
@@ -30,10 +30,9 @@ module.exports = function V(){
 
 
   // Add custom validator
-  v.custom = function(fn) {
-    checks.push(fn);
-    return v;
-  };
+  addCheck('custom', function(fn) {
+    return fn;
+  });
 
   var types = 'number string boolean object array buffer date'.split(' ');
   types.forEach(function(t){

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = function V(){
         };
       };
     }
-    
+
   });
 
   addCheck('notEqual', function(notExpected, msg){

--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ module.exports = function V(){
   };
 
 
-  // Add custom validator
   addCheck('custom', function(fn) {
     return fn;
   });

--- a/test/test.js
+++ b/test/test.js
@@ -507,3 +507,12 @@ test('putin', function(t) {
   });
 });
 
+
+test('custom', function(t) {
+  var trueCheck = function() {}
+  var falseCheck = function() { return 'Some error found' }
+
+  t.deepEqual(v().custom(trueCheck)(1).errors, [])
+  t.deepEqual(v().custom(falseCheck)(1).errors, ['Some error found'])
+  t.end()
+});

--- a/test/test.js
+++ b/test/test.js
@@ -509,10 +509,10 @@ test('putin', function(t) {
 
 
 test('custom', function(t) {
-  var trueCheck = function() {}
-  var falseCheck = function() { return 'Some error found' }
+  var trueCheck = function() {};
+  var falseCheck = function() { return 'Some error found'; };
 
-  t.deepEqual(v().custom(trueCheck)(1).errors, [])
-  t.deepEqual(v().custom(falseCheck)(1).errors, ['Some error found'])
-  t.end()
+  t.deepEqual(v().custom(trueCheck)(1).errors, []);
+  t.deepEqual(v().custom(falseCheck)(1).errors, ['Some error found']);
+  t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -53,7 +53,7 @@ test('boolean', function(t) {
       operator: 'boolean',
       actual: 'string',
       message: 'Expected a boolean but got a string'
-    } 
+    }
   ]);
   t.deepEqual(v().boolean('boolean')('true').errors, [
     {
@@ -61,7 +61,7 @@ test('boolean', function(t) {
       operator: 'boolean',
       actual: 'string',
       message: 'boolean'
-    } 
+    }
   ]);
   t.end();
 });
@@ -74,7 +74,7 @@ test('object', function(t) {
       operator: 'object',
       actual: 'string',
       message: 'Expected a object but got a string'
-    } 
+    }
   ]);
   t.deepEqual(v().object('object')('true').errors, [
     {
@@ -82,7 +82,7 @@ test('object', function(t) {
       operator: 'object',
       actual: 'string',
       message: 'object'
-    } 
+    }
   ]);
   t.end();
 });
@@ -137,7 +137,7 @@ test('date', function(t) {
       operator: 'date',
       actual: 'object',
       message: 'Expected a date but got a object'
-    } 
+    }
   ]);
   t.deepEqual(v().date('date')({}).errors, [
     {
@@ -145,7 +145,7 @@ test('date', function(t) {
       operator: 'date',
       actual: 'object',
       message: 'date'
-    } 
+    }
   ]);
   t.end();
 });
@@ -210,7 +210,7 @@ test('equal', function(t) {
       operator: 'equal',
       expected: '1',
       message: 'Expected 1 to equal "1"'
-    } 
+    }
   ]);
   t.deepEquals(v().equal({ gt: 4 })(3).errors, [
     {
@@ -218,7 +218,7 @@ test('equal', function(t) {
       operator: 'equal',
       expected: { gt: 4 },
       message: 'Expected a value in range (4,'
-    } 
+    }
   ]);
   t.deepEquals(v().equal({ gt: 4 }, 'equal')(3).errors, [
     {
@@ -226,7 +226,7 @@ test('equal', function(t) {
       operator: 'equal',
       expected: { gt: 4 },
       message: 'equal'
-    } 
+    }
   ]);
   t.deepEqual(v().equal({ gt: 'b' })('a').errors, [
     {


### PR DESCRIPTION
In this PR `addCheck` is made public to be able to add custom validators and an example is added to `README`.

I'd say that the API is confusing because custom validators cannot be added to `validimir` and make it available for every new validation function. I'd prefer something along these lines:

```js
var v = require('validimir')
v.addCheck('myCheck', function() { ... });
var fn = v().string().len(...).myCheck();
```

Please let me know your feedback/comments.

Related #2 