### PR TITLE
Fix equality checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function V(){
   });
 
   addCheck('equal', function(expected, msg){
-    if (Object(expected) === expected) {
+    if (isObj(expected)) {
       return function(v){
         if (!ltgt.contains(expected, v)) return {
           value: v,
@@ -77,7 +77,7 @@ module.exports = function V(){
   });
 
   addCheck('notEqual', function(notExpected, msg){
-    if (Object(notExpected) === notExpected) {
+    if (isObj(notExpected)) {
       return function(v){
         if (ltgt.contains(notExpected, v)) return {
           value: v,
@@ -200,3 +200,7 @@ function getLength(obj){
     : undefined;
 }
 
+
+function isObj(obj) {
+  return Object(obj) === obj
+}

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function V(){
   });
 
   addCheck('equal', function(expected, msg){
-    if (typeof expected == 'object') {
+    if (Object(expected) === expected) {
       return function(v){
         if (!ltgt.contains(expected, v)) return {
           value: v,

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = function V(){
   });
 
   addCheck('notEqual', function(notExpected, msg){
-    if (typeof notExpected == 'object') {
+    if (Object(notExpected) === notExpected) {
       return function(v){
         if (ltgt.contains(notExpected, v)) return {
           value: v,

--- a/test/test.js
+++ b/test/test.js
@@ -236,6 +236,15 @@ test('equal', function(t) {
       message: 'Expected a value in range (b,'
     }
   ]);
+  t.deepEqual(v().equal(null)('a').errors, [
+    {
+      value: 'a',
+      operator: 'equal',
+      expected: null,
+      message: 'Expected "a" to equal null'
+    }
+  ]);
+  t.deepEqual(v().equal(null)(null).errors, []);
   t.end();
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -279,6 +279,14 @@ test('notEqual', function(t) {
       message: 'not equal'
     }
   ]);
+  t.deepEqual(v().notEqual(null)(null).errors, [
+    {
+      value: null,
+      operator: 'notEqual',
+      message: 'Expected null not to equal null'
+    }
+  ]);
+  t.deepEqual(v().notEqual(null)('a').errors, []);
   t.end();
 });
 


### PR DESCRIPTION
This PR fixes `equal` and `notEqual` validators when using `null` values.

The problem basically is that `typeof null` is `'object'`, so it's better to check for an object using `Object(expected) === expected`.

 